### PR TITLE
Do not use chalk

### DIFF
--- a/can-symlink.js
+++ b/can-symlink.js
@@ -1,9 +1,8 @@
 #!/usr/bin/env node
 var canSymlink = require('./');
-var chalk = require('chalk');
 
 if (canSymlink()) {
-	console.log(chalk.green('Able to create symlinks.'));
+	console.log('Able to create symlinks.');
 } else {
-	console.log(chalk.red('Unable to create symlinks! Make sure your shell is running with the appropriate permissions.'));
+	console.log('Unable to create symlinks! Make sure your shell is running with the appropriate permissions.');
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,5 @@
     "mocha": "^2.1.0"
   },
   "dependencies": {
-    "chalk": "^0.5.1"
   }
 }


### PR DESCRIPTION
We are installing chalk plus several dependencies every time we install this
module, even though is not used at all when we use this module
programmatically.

It seems easiest to sacrifice colorful output for the can-symlink.js helper.
