### PR TITLE
Fix in a multiprocess environment

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,13 +1,11 @@
-var path = require('path');
+var tmp = require('tmp');
 
 module.exports = function testCanSymlink (options) {
   options = options || {};
   var fs = options.fs || require('fs');
-  var os = options.os || require('os');
-  var tmpdir = os.tmpdir();
 
-  var canLinkSrc  = path.join(tmpdir, "canLinkSrc.tmp")
-  var canLinkDest = path.join(tmpdir, "canLinkDest.tmp")
+  var canLinkSrc  = tmp.tmpNameSync();
+  var canLinkDest = tmp.tmpNameSync();
 
   try {
     fs.writeFileSync(canLinkSrc, '');

--- a/package.json
+++ b/package.json
@@ -20,5 +20,6 @@
     "mocha": "^2.1.0"
   },
   "dependencies": {
+    "tmp": "0.0.28"
   }
 }


### PR DESCRIPTION
`testCanSymlink` could throw ENOENT because another instance of can-symlink already unlinked the hardcoded filename. Use a unique tempfile name instead.

Example stack trace:

```
Error: ENOENT, no such file or directory '/tmp/canLinkSrc.tmp'
    at Object.fs.unlinkSync (fs.js:760:18)

    at testCanSymlink (/path/to/my/cool/app/node_modules/ember-cli/node_modules/ember-cli-preprocess-registry/node_modules/broccoli-merge-trees/node_modules/can-symlink/index.js:25:6)
    at Object.<anonymous> (/path/to/my/cool/app/node_modules/ember-cli/node_modules/ember-cli-preprocess-registry/node_modules/broccoli-merge-trees/index.js:9:40)
```
