### PR TITLE
Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# master
+
+# 1.0.0
+
+* Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # master
 
+* Short-circuit on non-Windows platforms unless `forceTest` option is passed
+* Use directory instead of file to test symlinking
+
 # 1.0.0
 
 * Initial release

--- a/README.md
+++ b/README.md
@@ -1,3 +1,32 @@
-# Can you create symlinks?
+# node-can-symlink
 
-Its easy to find out. Install using `npm install -g can-symlink`. Once installed run `can-symlink` to find out if you have what it takes to create symlinks. 
+This package tests whether you can create symlinks on this system.
+
+## Command-line usage
+
+```sh
+npm install -g can-symlink
+
+can-symlink
+```
+
+## Programmatic usage
+
+```sh
+npm install --save can-symlink
+```
+
+```js
+let canSymlink = require("can-symlink")();
+```
+
+`canSymlink` will be either `true` or `false`. Note that we are calling the
+module.
+
+On non-Windows platforms, `require("can-symlink")()` automatically returns true.
+To force testing for symlinkability on non-Windows platforms, pass the
+`forceTest` option:
+
+```js
+let canSymlink = require("can-symlink")({ forceTest: true });
+```

--- a/index.js
+++ b/index.js
@@ -2,25 +2,30 @@ var tmp = require("tmp");
 
 module.exports = function testCanSymlink(options) {
   options = options || {};
+
+  if (!options.forceTest && process.platform !== "win32") {
+    return true;
+  }
+
   var fs = options.fs || require("fs");
 
   var canLinkSrc = tmp.tmpNameSync();
   var canLinkDest = tmp.tmpNameSync();
 
   try {
-    fs.writeFileSync(canLinkSrc, "");
+    fs.mkdirSync(canLinkSrc);
   } catch (e) {
     return false;
   }
 
   try {
-    fs.symlinkSync(canLinkSrc, canLinkDest);
+    fs.symlinkSync(canLinkSrc, canLinkDest, "dir");
   } catch (e) {
-    fs.unlinkSync(canLinkSrc);
     return false;
+  } finally {
+    fs.rmdirSync(canLinkSrc);
   }
 
-  fs.unlinkSync(canLinkSrc);
   fs.unlinkSync(canLinkDest);
 
   return true;

--- a/index.js
+++ b/index.js
@@ -1,27 +1,27 @@
-var tmp = require('tmp');
+var tmp = require("tmp");
 
-module.exports = function testCanSymlink (options) {
+module.exports = function testCanSymlink(options) {
   options = options || {};
-  var fs = options.fs || require('fs');
+  var fs = options.fs || require("fs");
 
-  var canLinkSrc  = tmp.tmpNameSync();
+  var canLinkSrc = tmp.tmpNameSync();
   var canLinkDest = tmp.tmpNameSync();
 
   try {
-    fs.writeFileSync(canLinkSrc, '');
+    fs.writeFileSync(canLinkSrc, "");
   } catch (e) {
-    return false
+    return false;
   }
 
   try {
-    fs.symlinkSync(canLinkSrc, canLinkDest)
+    fs.symlinkSync(canLinkSrc, canLinkDest);
   } catch (e) {
-    fs.unlinkSync(canLinkSrc)
-    return false
+    fs.unlinkSync(canLinkSrc);
+    return false;
   }
 
-  fs.unlinkSync(canLinkSrc)
-  fs.unlinkSync(canLinkDest)
+  fs.unlinkSync(canLinkSrc);
+  fs.unlinkSync(canLinkDest);
 
-  return true
-}
+  return true;
+};

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -6,9 +6,11 @@ describe("can-symlink", function() {
     var options = {
       fs: {
         symlinkSync: function() {},
-        writeFileSync: function() {},
+        mkdirSync: function() {},
+        rmdirSync: function() {},
         unlinkSync: function() {}
-      }
+      },
+      forceTest: true
     };
 
     assert.equal(canSymlink(options), true);
@@ -20,11 +22,21 @@ describe("can-symlink", function() {
         symlinkSync: function() {
           throw Error("Symlink failed");
         },
-        writeFileSync: function() {},
+        mkdirSync: function() {},
+        rmdirSync: function() {},
         unlinkSync: function() {}
-      }
+      },
+      forceTest: true
     };
 
     assert.equal(canSymlink(options), false);
+  });
+
+  it("works on the real file-system", function() {
+    let result = canSymlink({ forceTest: true });
+    // On win32 we only care that we do not get an exception
+    if (process.platform !== "win32") {
+      assert.equal(result, true);
+    }
   });
 });

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1,37 +1,27 @@
-var assert = require('assert');
-var canSymlink = require('..');
+var assert = require("assert");
+var canSymlink = require("..");
 
-describe('can-symlink', function() {
-  it('returns true if no exceptions are thrown', function() {
+describe("can-symlink", function() {
+  it("returns true if no exceptions are thrown", function() {
     var options = {
       fs: {
-        symlinkSync: function() {
-          // noop
-        },
-        writeFileSync: function() {
-
-        },
-        unlinkSync: function() {
-          
-        }
+        symlinkSync: function() {},
+        writeFileSync: function() {},
+        unlinkSync: function() {}
       }
     };
 
     assert.equal(canSymlink(options), true);
   });
 
-  it('returns false if exceptions are thrown', function() {
+  it("returns false if exceptions are thrown", function() {
     var options = {
       fs: {
         symlinkSync: function() {
-          throw Error('Symlink failed');
+          throw Error("Symlink failed");
         },
-        writeFileSync: function() {
-
-        },
-        unlinkSync: function() {
-          
-        }
+        writeFileSync: function() {},
+        unlinkSync: function() {}
       }
     };
 


### PR DESCRIPTION
* Short-circuit on non-Windows platforms unless `forceTest` option is passed
* Use directory instead of file to test symlinking (https://github.com/broccolijs/node-symlink-or-copy/issues/35)
* Expand README
