### PR TITLE
update tmp package to latest and add a basic CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request: {}
+
+concurrency:
+  group: ci-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: "Tests"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        node:
+          - 14
+          - 16
+          - 18
+          - 20
+          - 22
+          - 24
+
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{matrix.node}}
+      - run: npm install
+      - run: npm test

--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
     "mocha": "^2.1.0"
   },
   "dependencies": {
-    "tmp": "0.0.28"
+    "tmp": "0.2.7"
+  },
+  "engines": {
+    "node": ">=14.14"
   }
 }


### PR DESCRIPTION
This PR adds an engine `"node": ">=14.14"` which matches what tmp supports with the updated version 👍 